### PR TITLE
Add minimal Second chat system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
+# Second - AI Persona Chat System
 
-# Mutsu
+This repository contains a minimal implementation of the "Second" web application described in the requirements. It is split into a FastAPI backend and a Next.js frontend.
+
+## Backend
+
+* Located in `backend/`
+* Run with `uvicorn backend.main:app --reload`
+* Endpoints:
+  * `GET /summon` - return a random character from `data/second_list.json`
+  * `POST /chat` - echo chat endpoint accepting `{character_id, message}`
+
+## Frontend
+
+* Located in `frontend/`
+* Standard Next.js project structure in the `pages` directory
+* API route in `pages/api/chat.ts` proxies requests to the backend
+
+This implementation is intentionally lightweight and uses placeholder images. It is meant as a starting point for further development.

--- a/backend/data/second_list.json
+++ b/backend/data/second_list.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "alice",
+    "name": "Alice",
+    "attribute": "support",
+    "icon": "/images/alice.png"
+  },
+  {
+    "id": "bob",
+    "name": "Bob",
+    "attribute": "battle",
+    "icon": "/images/bob.png"
+  }
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import random
+import json
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+class ChatRequest(BaseModel):
+    character_id: str
+    message: str
+
+class ChatResponse(BaseModel):
+    reply: str
+
+def load_seconds():
+    with open('backend/data/second_list.json', 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+@app.get('/summon')
+def summon():
+    seconds = load_seconds()
+    if not seconds:
+        raise HTTPException(status_code=500, detail='No seconds available')
+    return random.choice(seconds)
+
+@app.post('/chat', response_model=ChatResponse)
+def chat(req: ChatRequest):
+    # For MVP, respond with a simple echo using the selected character name
+    seconds = {s['id']: s for s in load_seconds()}
+    second = seconds.get(req.character_id)
+    if not second:
+        raise HTTPException(status_code=404, detail='Character not found')
+    reply = f"{second['name']} says: {req.message}"
+    return ChatResponse(reply=reply)

--- a/frontend/pages/api/chat.ts
+++ b/frontend/pages/api/chat.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  const { character_id, message } = req.body
+  const resp = await fetch('http://localhost:8000/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ character_id, message })
+  })
+  const data = await resp.json()
+  res.status(200).json(data)
+}

--- a/frontend/pages/chat.tsx
+++ b/frontend/pages/chat.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+export default function Chat() {
+  const router = useRouter()
+  const { id } = router.query
+  const [input, setInput] = useState('')
+  const [logs, setLogs] = useState<string[]>([])
+
+  const send = async () => {
+    if (!id) return
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ character_id: id, message: input })
+    })
+    const data = await res.json()
+    setLogs([...logs, `You: ${input}`, data.reply])
+    setInput('')
+  }
+
+  useEffect(() => {
+    const saved = localStorage.getItem('chatLogs')
+    if (saved) setLogs(JSON.parse(saved))
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('chatLogs', JSON.stringify(logs))
+  }, [logs])
+
+  return (
+    <div className="p-4">
+      <div className="mb-4">
+        {logs.map((l, i) => <div key={i}>{l}</div>)}
+      </div>
+      <input value={input} onChange={e => setInput(e.target.value)} className="border" />
+      <button onClick={send} className="ml-2 px-2 py-1 bg-blue-500 text-white rounded">Send</button>
+    </div>
+  )
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link'
+import Image from 'next/image'
+
+export default function Home() {
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center">
+      <Image src="/images/second_cover.png" alt="cover" width={400} height={300} />
+      <Link href="/summon" className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">Enter</Link>
+    </div>
+  )
+}

--- a/frontend/pages/summon.tsx
+++ b/frontend/pages/summon.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import Image from 'next/image'
+
+export default function Summon() {
+  const [second, setSecond] = useState<any>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    fetch('http://localhost:8000/summon')
+      .then(res => res.json())
+      .then(setSecond)
+  }, [])
+
+  if (!second) return <div>Loading...</div>
+
+  const select = () => {
+    router.push({ pathname: '/chat', query: { id: second.id } })
+  }
+
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-xl mb-4">Summoned Second</h1>
+      <Image src={second.icon} alt={second.name} width={100} height={100} />
+      <p>{second.name}</p>
+      <button onClick={select} className="mt-2 px-3 py-1 bg-green-500 text-white rounded">Choose</button>
+    </div>
+  )
+}

--- a/frontend/public/images/alice.png
+++ b/frontend/public/images/alice.png
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/public/images/bob.png
+++ b/frontend/public/images/bob.png
@@ -1,0 +1,1 @@
+placeholder

--- a/frontend/public/images/second_cover.png
+++ b/frontend/public/images/second_cover.png
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- add FastAPI backend with /summon and /chat
- add sample characters in JSON
- create Next.js pages for index, summon, chat
- add API route to call backend
- include placeholder images and project README

## Testing
- `python3 -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6842ce532798832984bce354e035698f