### PR TITLE
Add mirage-intake project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 node_modules/
 frontend/.next/
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  backend:
+    build: ./mirage-intake/backend
+    volumes:
+      - ./mirage-intake/backend:/app
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./mirage-intake/frontend
+    volumes:
+      - ./mirage-intake/frontend:/app
+    ports:
+      - "3000:5173"
+    depends_on:
+      - backend

--- a/mirage-intake/backend/Dockerfile
+++ b/mirage-intake/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/mirage-intake/backend/database.py
+++ b/mirage-intake/backend/database.py
@@ -1,0 +1,18 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).parent / "app.db"
+
+def get_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS answers (id INTEGER PRIMARY KEY AUTOINCREMENT, question TEXT, answer TEXT)"
+    )
+    conn.commit()
+    conn.close()

--- a/mirage-intake/backend/main.py
+++ b/mirage-intake/backend/main.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+from .routes import router
+from .database import init_db
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+
+@app.on_event("startup")
+def on_startup():
+    init_db()

--- a/mirage-intake/backend/models.py
+++ b/mirage-intake/backend/models.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+class Question(BaseModel):
+    id: int
+    text: str
+
+class Answer(BaseModel):
+    question_id: int
+    answer: str
+
+class Analysis(BaseModel):
+    summary: str

--- a/mirage-intake/backend/requirements.txt
+++ b/mirage-intake/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/mirage-intake/backend/routes.py
+++ b/mirage-intake/backend/routes.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter
+from .models import Question, Answer, Analysis
+from .database import get_connection
+
+router = APIRouter()
+
+QUESTIONS = [
+    {"id": 1, "text": "How do you feel today?"},
+    {"id": 2, "text": "What motivates you?"},
+    {"id": 3, "text": "What is your biggest challenge?"},
+    {"id": 4, "text": "How do you handle stress?"},
+    {"id": 5, "text": "What are your goals?"},
+]
+
+@router.get("/questions", response_model=list[Question])
+def get_questions():
+    return QUESTIONS
+
+@router.post("/answers")
+def save_answer(ans: Answer):
+    conn = get_connection()
+    cur = conn.cursor()
+    question_text = next((q["text"] for q in QUESTIONS if q["id"] == ans.question_id), "")
+    cur.execute(
+        "INSERT INTO answers (question, answer) VALUES (?, ?)",
+        (question_text, ans.answer),
+    )
+    conn.commit()
+    conn.close()
+    return {"status": "ok"}
+
+@router.get("/analysis", response_model=Analysis)
+def analysis():
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT answer FROM answers")
+    answers = [row["answer"] for row in cur.fetchall()]
+    conn.close()
+    summary = " ".join(answers)
+    return Analysis(summary=summary)

--- a/mirage-intake/frontend/Dockerfile
+++ b/mirage-intake/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/mirage-intake/frontend/index.html
+++ b/mirage-intake/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mirage Intake</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/mirage-intake/frontend/package.json
+++ b/mirage-intake/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mirage-intake",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.4.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/mirage-intake/frontend/src/App.tsx
+++ b/mirage-intake/frontend/src/App.tsx
@@ -1,0 +1,16 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import QuestionPage from './pages/QuestionPage';
+import ResultPage from './pages/ResultPage';
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<QuestionPage />} />
+        <Route path="/result" element={<ResultPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default App;

--- a/mirage-intake/frontend/src/api/index.ts
+++ b/mirage-intake/frontend/src/api/index.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api'
+});
+
+export default api;

--- a/mirage-intake/frontend/src/main.tsx
+++ b/mirage-intake/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/mirage-intake/frontend/src/pages/QuestionPage.tsx
+++ b/mirage-intake/frontend/src/pages/QuestionPage.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+function QuestionPage() {
+  const [questions, setQuestions] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<string[]>([]);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    api.get('/questions').then(res => setQuestions(res.data.map((q: any) => q.text)));
+  }, []);
+
+  const submit = () => {
+    api.post('/answers', { question_id: index + 1, answer: answers[index] }).then(() => {
+      if (index + 1 < questions.length) {
+        setIndex(index + 1);
+      } else {
+        window.location.href = '/result';
+      }
+    });
+  };
+
+  return (
+    <div>
+      {questions.length > 0 && (
+        <div>
+          <p>{questions[index]}</p>
+          <input
+            value={answers[index] || ''}
+            onChange={e => {
+              const newAns = [...answers];
+              newAns[index] = e.target.value;
+              setAnswers(newAns);
+            }}
+          />
+          <button onClick={submit}>Next</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default QuestionPage;

--- a/mirage-intake/frontend/src/pages/ResultPage.tsx
+++ b/mirage-intake/frontend/src/pages/ResultPage.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import api from '../api';
+
+function ResultPage() {
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    api.get('/analysis').then(res => setSummary(res.data.summary));
+  }, []);
+
+  return (
+    <div>
+      <h1>Result</h1>
+      <p>{summary}</p>
+    </div>
+  );
+}
+
+export default ResultPage;

--- a/mirage-intake/frontend/tsconfig.json
+++ b/mirage-intake/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{"path": "./tsconfig.node.json"}]
+}

--- a/mirage-intake/frontend/tsconfig.node.json
+++ b/mirage-intake/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/mirage-intake/frontend/vite.config.ts
+++ b/mirage-intake/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- create new `mirage-intake` project with FastAPI backend and React + Vite frontend
- wire backend and frontend together using docker-compose
- ignore `.env` files so API keys are not committed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843880a614483299aecceb081c4b35b